### PR TITLE
fix(test-suite-run): Run test suites in serial order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "@sasjs/test-framework",
-  "requires": true,
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.10.4",
@@ -8562,10 +8562,9 @@
       "dev": true
     },
     "immer": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz",
-      "integrity": "sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==",
-      "dev": true
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-7.0.7.tgz",
+      "integrity": "sha512-Q8yYwVADJXrNfp1ZUAh4XDHkcoE3wpdpb4mC5abDSajs2EbW8+cGdPyAnglMyLnm7EF6ojD2xBFX7L5i4TIytw=="
     },
     "import-cwd": {
       "version": "3.0.0",
@@ -13979,6 +13978,12 @@
           "version": "3.3.10",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
           "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+          "dev": true
+        },
+        "immer": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz",
+          "integrity": "sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==",
           "dev": true
         },
         "inquirer": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   ],
   "dependencies": {
     "@types/react-highlight.js": "^1.0.0",
+    "immer": "^7.0.7",
     "moment": "^2.27.0",
     "react-highlight.js": "^1.0.7",
     "semantic-ui-css": "^2.4.1",

--- a/src/components/TestCard.scss
+++ b/src/components/TestCard.scss
@@ -6,6 +6,7 @@
   border: 1px solid #ddd;
   border-radius: 5px;
   width: 20%;
+  min-height: 150px;
 
   .title {
     font-weight: bold;

--- a/src/components/TestCard.scss
+++ b/src/components/TestCard.scss
@@ -7,6 +7,7 @@
   border-radius: 5px;
   width: 20%;
   min-height: 150px;
+  min-width: 375px;
 
   .title {
     font-weight: bold;

--- a/src/components/TestCard.tsx
+++ b/src/components/TestCard.tsx
@@ -6,7 +6,7 @@ interface TestCardProps {
   description: string;
   status: string;
   error: Error | null;
-  executionTime?: number;
+  executionTime?: number | null;
   onRerun?: () => void;
 }
 const TestCard = (props: TestCardProps): ReactElement<TestCardProps> => {
@@ -17,8 +17,13 @@ const TestCard = (props: TestCardProps): ReactElement<TestCardProps> => {
       <div>
         <code className="title">{title}</code>
         {!!onRerun && (
-          <button className="re-run-button" onClick={onRerun}>
-            Re-run
+          <button
+            className={`re-run-button ${
+              status === "running" ? "disabled" : ""
+            }`}
+            onClick={onRerun}
+          >
+            {status === "running" ? "Running" : "Re-run"}
           </button>
         )}
       </div>

--- a/src/components/TestSuiteCard.scss
+++ b/src/components/TestSuiteCard.scss
@@ -31,4 +31,10 @@
   border-radius: 5px;
   padding: 5px;
   margin-left: 10px;
+
+  &.disabled {
+    background-color: #787b93;
+    pointer-events: none;
+    cursor: not-allowed;
+  }
 }

--- a/src/components/TestSuiteCard.tsx
+++ b/src/components/TestSuiteCard.tsx
@@ -7,9 +7,10 @@ interface TestSuiteCardProps {
   name: string;
   tests: {
     test: Test;
+    isRunning?: boolean;
     result: boolean;
     error: Error | null;
-    executionTime: number;
+    executionTime: number | null;
   }[];
   onRerun: () => void;
   onRerunTest: (test: Test) => void;
@@ -19,17 +20,25 @@ const TestSuiteCard = (
 ): ReactElement<TestSuiteCardProps> => {
   const { name, tests, onRerun, onRerunTest } = props;
   const overallStatus = tests.map((t) => t.result).reduce((x, y) => x && y);
+  const isSuiteRunning = tests.map((t) => t.isRunning).reduce((x, y) => x || y);
 
   return (
     <div className="test-suite">
-      <div className={`test-suite-name ${overallStatus ? "passed" : "failed"}`}>
+      <div
+        className={`test-suite-name ${
+          isSuiteRunning ? "running" : overallStatus ? "passed" : "failed"
+        }`}
+      >
         {name}
-        <button className="re-run-button" onClick={onRerun}>
-          Re-run
+        <button
+          className={`re-run-button ${isSuiteRunning ? "disabled" : ""}`}
+          onClick={onRerun}
+        >
+          {isSuiteRunning ? "Running" : "Re-run"}
         </button>
       </div>
       {tests.map((completedTest, index) => {
-        const { test, result, error, executionTime } = completedTest;
+        const { test, result, error, executionTime, isRunning } = completedTest;
         const { title, description } = test;
         return (
           <TestCard
@@ -37,7 +46,9 @@ const TestSuiteCard = (
             title={title}
             onRerun={() => onRerunTest(test)}
             description={description}
-            status={result === true ? "passed" : "failed"}
+            status={
+              isRunning ? "running" : result === true ? "passed" : "failed"
+            }
             error={error}
             executionTime={executionTime}
           />

--- a/src/utils/runTest.ts
+++ b/src/utils/runTest.ts
@@ -1,0 +1,30 @@
+import { Test } from "../types";
+
+export async function runTest(
+  testToRun: Test,
+  context: any
+): Promise<{ result: any; error: any; executionTime: number }> {
+  const { test, assertion, beforeTest, afterTest } = testToRun;
+  const beforeTestFunction = beforeTest ? beforeTest : () => Promise.resolve();
+  const afterTestFunction = afterTest ? afterTest : () => Promise.resolve();
+
+  const startTime = new Date().valueOf();
+
+  return beforeTestFunction()
+    .then(() => test(context))
+    .then((res) => {
+      return Promise.resolve(assertion(res, context));
+    })
+    .then((testResult) => {
+      afterTestFunction();
+      const endTime = new Date().valueOf();
+      const executionTime = (endTime - startTime) / 1000;
+      return { result: testResult, error: null, executionTime };
+    })
+    .catch((e) => {
+      console.error(e);
+      const endTime = new Date().valueOf();
+      const executionTime = (endTime - startTime) / 1000;
+      return { result: false, error: e, executionTime };
+    });
+}


### PR DESCRIPTION
* Run test suites and tests one by one, rather than in parallel.
* Re-implement rerun feature to keep tests from changing order.
* Disabled re-run button when a test or suite is running.