### PR TITLE
Fixed access token in github actions

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -35,5 +35,5 @@ jobs:
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "semantic-ui-react": "^2.1.3"
       },
       "devDependencies": {
-        "@sasjs/adapter": "4.0.0",
+        "@sasjs/adapter": "^4.8.0",
         "@testing-library/jest-dom": "^5.11.4",
         "@testing-library/react": "^12.0.0",
         "@testing-library/user-event": "^13.2.1",
@@ -54,6 +54,7 @@
         "node": ">=10"
       },
       "peerDependencies": {
+        "@sasjs/adapter": "^4.8.0",
         "react": "^16.0.0",
         "react-dom": "^16.13.1"
       }
@@ -3183,24 +3184,24 @@
       "dev": true
     },
     "node_modules/@sasjs/adapter": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.0.0.tgz",
-      "integrity": "sha512-21DKLwqGI4zLibqX+RbicP6+xDw67489Y7jQLb1D/GEw5DpvDUNB7cfE0a+mz+wsSVRxKkGuKHkFaDMA6kZ+KA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.8.0.tgz",
+      "integrity": "sha512-1eGQfhZcp2pTbCZKbCEABC3+Kz8B4PRWqJZG9XAhh9QkFAR+ENRKAkbk5Sf+xa9YS+ycz7SvusmYYInGZ9b54w==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@sasjs/utils": "2.48.2",
-        "axios": "0.26.0",
+        "@sasjs/utils": "2.52.0",
+        "axios": "0.27.2",
         "axios-cookiejar-support": "1.0.1",
         "form-data": "4.0.0",
         "https": "1.0.0",
-        "tough-cookie": "4.0.0"
+        "tough-cookie": "4.1.3"
       }
     },
     "node_modules/@sasjs/utils": {
-      "version": "2.48.2",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.48.2.tgz",
-      "integrity": "sha512-FdKtHw7uVNChDB6Ym3LqqMo7sR2vBc40M68LrS/ud1PpFJrXbJjNO8qL4MXAUo+2Gt0ZRZIjDvSEEv5smebUnA==",
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.52.0.tgz",
+      "integrity": "sha512-UbmYCdfCvjRpmoKRnbmKEcE2YZJh9zHjjGyuZ5BIDxThDtOsGZUOiZrW1J7WcrzjAwQiRBzYoV7xF5MiZqtgiQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -4923,11 +4924,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.26.0",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/axios-cookiejar-support": {
@@ -16240,6 +16243,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -21401,16 +21410,27 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.0.0",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/tr46": {
@@ -21743,6 +21763,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -25063,23 +25093,23 @@
       "dev": true
     },
     "@sasjs/adapter": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.0.0.tgz",
-      "integrity": "sha512-21DKLwqGI4zLibqX+RbicP6+xDw67489Y7jQLb1D/GEw5DpvDUNB7cfE0a+mz+wsSVRxKkGuKHkFaDMA6kZ+KA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.8.0.tgz",
+      "integrity": "sha512-1eGQfhZcp2pTbCZKbCEABC3+Kz8B4PRWqJZG9XAhh9QkFAR+ENRKAkbk5Sf+xa9YS+ycz7SvusmYYInGZ9b54w==",
       "dev": true,
       "requires": {
-        "@sasjs/utils": "2.48.2",
-        "axios": "0.26.0",
+        "@sasjs/utils": "2.52.0",
+        "axios": "0.27.2",
         "axios-cookiejar-support": "1.0.1",
         "form-data": "4.0.0",
         "https": "1.0.0",
-        "tough-cookie": "4.0.0"
+        "tough-cookie": "4.1.3"
       }
     },
     "@sasjs/utils": {
-      "version": "2.48.2",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.48.2.tgz",
-      "integrity": "sha512-FdKtHw7uVNChDB6Ym3LqqMo7sR2vBc40M68LrS/ud1PpFJrXbJjNO8qL4MXAUo+2Gt0ZRZIjDvSEEv5smebUnA==",
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.52.0.tgz",
+      "integrity": "sha512-UbmYCdfCvjRpmoKRnbmKEcE2YZJh9zHjjGyuZ5BIDxThDtOsGZUOiZrW1J7WcrzjAwQiRBzYoV7xF5MiZqtgiQ==",
       "dev": true,
       "requires": {
         "@types/fs-extra": "9.0.13",
@@ -26366,10 +26396,13 @@
       "dev": true
     },
     "axios": {
-      "version": "0.26.0",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dev": true,
       "requires": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "axios-cookiejar-support": {
@@ -34455,6 +34488,12 @@
         "side-channel": "^1.0.4"
       }
     },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -37951,12 +37990,23 @@
       "dev": true
     },
     "tough-cookie": {
-      "version": "4.0.0",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dev": true,
       "requires": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+          "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+          "dev": true
+        }
       }
     },
     "tr46": {
@@ -38181,6 +38231,16 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
     "lint:fix": "npx prettier --loglevel silent --write \"src/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}\" && npx prettier --loglevel silent --write \"sasjs-tests/src/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}\" && npx prettier --loglevel silent --write \"cypress/**/*.{ts,tsx,js,jsx,html,css,sass,less,json,yml,md,graphql}\""
   },
   "peerDependencies": {
-    "@sasjs/adapter": "^4.0.0",
+    "@sasjs/adapter": "^4.8.0",
     "react": "^16.0.0",
     "react-dom": "^16.13.1"
   },
   "devDependencies": {
-    "@sasjs/adapter": "4.0.0",
+    "@sasjs/adapter": "^4.8.0",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^12.0.0",
     "@testing-library/user-event": "^13.2.1",


### PR DESCRIPTION
## Intent

- Bump `@sasjs` packages.
- Use `GITHUB_TOKEN` as an access token in github actions.

## Implementation

- Bumped `@sasjs/adapter`.
- Updated `.github/workflows/npmpublish.yml`.

## Checks

- [ ] Code is formatted correctly (`npm run lint:fix`).
- [ ] Any new functionality has been unit tested.
- [ ] All unit tests are passing (`npm test`).
- [ ] All CI checks are green.
- [ ] Reviewer is assigned.
